### PR TITLE
fix: automerge-action version

### DIFF
--- a/.github/workflows/pr_auto_merge.yaml
+++ b/.github/workflows/pr_auto_merge.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: automerge
-        uses: "pascalgn/automerge-action@v0.15.7"
+        uses: "pascalgn/automerge-action@v0.15.6"
         env:
           MERGE_LABELS: "" # 모든 PR을 병합합니다.
           MERGE_METHOD: "squash" # PR을 스쿼시형태로 병합합니다.


### PR DESCRIPTION
### Changes

`v0.15.7` 이 없기 때문에 action 이 실패합니다. **가장 최근 버전인 `v0.15.6` 로 수정**하여 문제 해결을 시도합니다.

참고: https://github.com/pascalgn/automerge-action